### PR TITLE
Add deleteIfExists() method to migrator

### DIFF
--- a/src/Migrations/SettingsMigrator.php
+++ b/src/Migrations/SettingsMigrator.php
@@ -70,6 +70,13 @@ class SettingsMigrator
         $this->deleteProperty($property);
     }
 
+    public function deleteIfExists(string $property): void
+    {
+        if ($this->checkIfPropertyExists($property)) {
+            $this->deleteProperty($property);
+        }
+    }
+    
     public function update(string $property, Closure $closure, bool $encrypted = false): void
     {
         if (! $this->checkIfPropertyExists($property)) {


### PR DESCRIPTION
We recently ran into an edge case where we had to delete some code from an old settings migration to avoid an error after the deletion of a class.

This meant that a subsequent migration failed on a new `migrate:fresh` due to the missing property no longer being created in the first place. It would be nice if `SettingsMigrator::deleteIfExists()` existed to allow conditional dropping of a property.

This creates some feature parity with `$schema->dropIfExists()`.

